### PR TITLE
fix: use perusahaan id on select instead of name

### DIFF
--- a/src/pages/barang/page.tsx
+++ b/src/pages/barang/page.tsx
@@ -138,7 +138,7 @@ const BarangPage = () => {
           >
             <option value="">Semua Perusahaan</option>
             {listPerusahaan.map((p) => (
-              <option key={p.id} value={p.nama}>
+              <option key={p.id} value={p.id}>
                 {p.nama}
               </option>
             ))}


### PR DESCRIPTION
Beberapa orang kebingungan karena mengiranya yang dijadikan filter untuk list barang itu perusahaan id bukan nama. Ini juga lebih masuk akal karena nama kan tidak unik sedangkan id unik jadi benar2 merepresentasikan filter untuk suatu perusahaan. Selain itu, jika menggunakan filter nama, diperlukan join pada querynya dan kurang efektif.